### PR TITLE
Fix link on resources index

### DIFF
--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -12,9 +12,9 @@
     </thead>
     <tbody>
     	<% @resources.each do |resource| %>
-    	  <tr onclick="location.href='<%= edit_resource_path(resource) %>'">
-    	  	<td><%= resource.title %></td>
-    	  	<td><%= resource.description %></td>
+    	  <tr>
+    	  	<td onclick="location.href='<%= edit_resource_path(resource) %>'"><%= resource.title %></td>
+    	  	<td onclick="location.href='<%= edit_resource_path(resource) %>'"><%= resource.description %></td>
     	  	<td><%= link_to("Go", resource.url, :target => "_blank") %></td>
     	  </tr>
     	<% end %>


### PR DESCRIPTION
Links in resources index didn't work in Safari. It used to be the case that by clicking on the Name or Description the user would be directed to the edit-page, but by clicking on "Go" one wouldn't go to the URL (in Safari). 
