### PR TITLE
Revert "Include psych explicitly to prevent conflicts with other apps."

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :assets do
 end
 
 
-gem 'psych'
+
 gem 'jquery-rails'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,6 @@ GEM
     mime-types (1.21)
     multi_json (1.6.1)
     polyglot (0.3.3)
-    psych (1.3.4)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -114,7 +113,6 @@ DEPENDENCIES
   bootstrap-sass
   coffee-rails (~> 3.2.1)
   jquery-rails
-  psych
   rails (>= 3.2.12)
   sass-rails (~> 3.2.3)
   sqlite3


### PR DESCRIPTION
This reverts commit 38384f5e697187f5b46de0a61b88c64bf8806863.

I ran into this error when trying to run any other rails app: https://github.com/rails/rails/issues/3488

You don't need to have psych as gem anyway, since it's in stdlib.
