### PR TITLE
use different cache store in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,4 +34,7 @@ RailsGirls::Application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  # Use a different cache store in development
+  config.cache_store = :memory_store
 end


### PR DESCRIPTION
In development when loading home page, turning server off and on again within ten minutes and loading home page again you would get an error. By using memory_store we make sure the meetup cache is cleared when restarting the rails server.
This problem does not exist in production.
